### PR TITLE
change directory to generate kernel modules

### DIFF
--- a/unleashed/Readme.md
+++ b/unleashed/Readme.md
@@ -169,6 +169,7 @@ Check if building produced the files `linux/arch/riscv/boot/Image` and `linux/ar
 ### Generating Kernel modules
 
 ```bash
+cd linux/
 rm -rf modules_install
 mkdir -p modules_install
 CROSS_COMPILE=riscv64-unknown-linux-gnu- ARCH=riscv make modules_install INSTALL_MOD_PATH=./modules_install

--- a/unleashed/Readme.md
+++ b/unleashed/Readme.md
@@ -178,6 +178,7 @@ tar -cf kernel-modules-${version}.tar .
 gzip kernel-modules-${version}.tar
 popd
 mv ./modules_install/lib/modules/kernel-modules-${version}.tar.gz .
+cd ..
 ```
 
 ## Flashing to the SD Card


### PR DESCRIPTION
Though it is obvious that kernel modules will be built inside kernel
directory, but it may cause an ambiguity to novice user. Change
directory to linux directory when generating kernel modules.

Signed off by: Arshad Aleem <arshad.aleem@lampromellon.com>