### PR TITLE
Add a Dockerfile for cross-compiling traefik

### DIFF
--- a/Dockerfiles/Dockerfile.traefik
+++ b/Dockerfiles/Dockerfile.traefik
@@ -1,0 +1,39 @@
+# WEBUI
+FROM node:12.11 as webui
+
+RUN mkdir -p /src/webui
+
+COPY ./traefik/webui/ /src/webui/
+
+WORKDIR /src/webui
+
+RUN npm install
+RUN npm run build
+
+# BUILD
+FROM golang:1.17 as gobuild
+
+COPY ./traefik /go/src/github.com/traefik/traefik
+
+WORKDIR /go/src/github.com/traefik/traefik
+
+RUN rm -rf /go/src/github.com/traefik/traefik/webui/static/
+COPY --from=webui /src/webui/static/ /go/src/github.com/traefik/traefik/webui/static/
+
+# required to merge non-code components into the final binary,
+# such as the web dashboard/UI
+RUN go generate
+
+# cross-compile
+ENV GOARCH=riscv64
+ENV GOOS=linux
+
+# Standard go build
+RUN mkdir dist
+RUN go build -o dist/traefik ./cmd/traefik
+RUN chmod +x dist/traefik
+
+EXPOSE 80
+VOLUME ["/tmp"]
+
+ENTRYPOINT ["dist/traefik"]


### PR DESCRIPTION
There were some excellent instructions how to compile traefik for riscv, but I wanted to do it with Docker, and also to include the traefik webui in the image.

Based on the work done already, I packaged it all up in a Dockerfile and wrote some words of how to do it [here](https://gitlab.com/olof-nord/selfhosted/-/tree/main/proxy#docker-cross-compile).

Seeing the collection of docker images, perhaps this one would fit.

This build expects the traefik source code to be available alongside the Dockerfile.
