### PR TITLE
Add mariadb Dockerfile

### DIFF
--- a/Dockerfiles/Dockerfile.mariadb
+++ b/Dockerfiles/Dockerfile.mariadb
@@ -1,0 +1,15 @@
+FROM ubuntu:impish
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install mariadb-server gettext-base -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /var/run/mysqld && \
+    chown -R mysql:mysql /var/run/mysqld
+
+VOLUME ["/var/lib/mysql"]
+
+USER mysql
+
+EXPOSE 3306
+CMD ["mysqld"]

--- a/Dockerfiles/Dockerfile.mariadb
+++ b/Dockerfiles/Dockerfile.mariadb
@@ -1,7 +1,7 @@
 FROM ubuntu:impish
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install mariadb-server gettext-base -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install mariadb-server -y && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /var/run/mysqld && \


### PR DESCRIPTION
There is no official risc-v mariadb Docker image, but Ubuntu provides binaries.

This PR adds a Dockerfile for building a mariadb server docker image.