### PR TITLE
Align the mariadb and traefik Dockerfiles to existing Dockerfiles

### DIFF
--- a/Dockerfiles/Dockerfile.mariadb
+++ b/Dockerfiles/Dockerfile.mariadb
@@ -1,3 +1,5 @@
+# Run: docker build -t carlosedp/mariadb -f Dockerfile.mariadb .
+
 FROM ubuntu:impish
 
 RUN apt-get update && \

--- a/Dockerfiles/Dockerfile.traefik
+++ b/Dockerfiles/Dockerfile.traefik
@@ -1,9 +1,17 @@
+# Run: docker build -t carlosedp/traefik -f Dockerfile.traefik .
+
+# FETCH
+FROM alpine:3 as gitfetch
+RUN apk add --no-cache git
+
+RUN git clone --depth 1 https://github.com/traefik/traefik.git /traefik
+
 # WEBUI
 FROM node:12.11 as webui
 
 RUN mkdir -p /src/webui
 
-COPY ./traefik/webui/ /src/webui/
+COPY --from=gitfetch /traefik/webui/ /src/webui/
 
 WORKDIR /src/webui
 
@@ -13,7 +21,7 @@ RUN npm run build
 # BUILD
 FROM golang:1.17 as gobuild
 
-COPY ./traefik /go/src/github.com/traefik/traefik
+COPY --from=gitfetch /traefik /go/src/github.com/traefik/traefik
 
 WORKDIR /go/src/github.com/traefik/traefik
 

--- a/Readme.md
+++ b/Readme.md
@@ -102,7 +102,7 @@ To run Docker on your RISC-V Debian or Ubuntu environment, download a [deb packa
 
 For other distros get the [tarball here](https://github.com/carlosedp/riscv-bringup/releases/download/v1.0/docker-v20.10.2-dev_riscv64.tar.gz) and unpack to your `/` dir. If the docker service doesn't start on install script, re-run `systemctl start docker`.
 
-<details><summary>Docker-compose install instructions</summary></u>
+<details><summary>Docker-compose install instructions</summary>
 
 ```bash
 # In Debian image
@@ -525,6 +525,8 @@ mkdir dist
 GOARCH=riscv64 GOOS=linux go build -o dist/traefik ./cmd/traefik
 docker build -t carlosedp/traefik:v2.1-riscv64 .
 ```
+
+See also [a complete Traefik Dockerfile for cross-compiling](./Dockerfiles/Dockerfile.traefik).
 
 To run an example stack with Docker Compose, create the file below and start it with `docker-compose up -d`. To test, you can open the address `http://[IP]:8080/dashboard` or `curl http://localhost:8080/api/rawdata`. Prometheus metrics are exposed on `http://localhost:8080/metrics`.
 


### PR DESCRIPTION
Seeing the existing Dockerfiles, align the new additions a bit more.

* Make the Trafik Dockerfile not need any external files (it fetches its own source files)
* Add example build command to mariadb and traefik Dockerfiles
* Add small note to Readme for the traefik Dockerfile
* Remove leftover `<u>` in Readme