### PR TITLE
Update Go version for Docker file carlosedp/golang to 1.23.6

### DIFF
--- a/Dockerfiles/Dockerfile.golang
+++ b/Dockerfiles/Dockerfile.golang
@@ -1,21 +1,17 @@
 # Run with
-# VER=1.19.2 bash -c 'docker buildx build -t carlosedp/golang:$VER -t carlosedp/golang:"$(echo $VER |cut -d. -f1-2)" --build-arg=VERSION=$VER --platform linux/amd64,linux/arm64,linux/ppc64le,linux/riscv64,linux/arm --push -f Dockerfile.golang .'
+# VER=1.23.6 bash -c 'docker buildx build -t carlosedp/golang:$VER -t carlosedp/golang:"$(echo $VER |cut -d. -f1-2)" --build-arg=VERSION=$VER --platform linux/amd64,linux/arm64,linux/ppc64le,linux/riscv64,linux/arm --push -f Dockerfile.golang .'
 
 FROM debian:sid-slim
 ARG VERSION
 ARG TARGETARCH
 
-ENV GOLANG_VERSION $VERSION
+ENV GOLANG_VERSION=${VERSION}
 
 RUN apt-get update && apt-get install -y ca-certificates curl libc6 --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/local && \
     set -eux; \
-    if [ "$TARGETARCH" = "riscv64" ]; then                                       \
-        URL="https://github.com/carlosedp/riscv-bringup/releases/download/v1.0"; \
-    else                                                                         \
-        URL="https://golang.org/dl";                                             \
-    fi &&                                                                        \
+    URL="https://go.dev/dl";                                                     \
     if [ "$TARGETARCH" = "arm" ]; then export TARGETARCH=armv6l; fi &&           \
     curl -L $URL/go${GOLANG_VERSION}.linux-$TARGETARCH.tar.gz --output go${GOLANG_VERSION}.tar.gz && \
     tar vxf go${GOLANG_VERSION}.tar.gz -C /usr/local/ && \
@@ -24,8 +20,8 @@ RUN mkdir -p /usr/local && \
 RUN export PATH="/usr/local/go/bin:$PATH"; \
     /usr/local/go/bin/go version
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH


### PR DESCRIPTION
### Background

The Docker image `carlosedp/golang` is quite extensively used by other Docker images (in the build process). For instance, the `shenxn/protonmail-bridge` relies on the Go image to build the mail bridge.
For them to be updated, the `carlosedp/golang` should be bumped to a newer version of Go. I have made small changes to the `Dockerfile.golang` to allow updating to Go version 1.23.6. I have tested this with success on two different architectures.

### Changelog

- Updated `VER` variable to `1.23.6`.
- Changed Golang download URL to current base URL.
- Removed alternative RISCV64 download location (i.e. Go archive in this GitHub repository), as Go releases now ship a RISCV64 version from the [downloads](https://go.dev/dl/) by default.
- Changed ENV declarations format in `Dockerfile.golang` as these were using an outdated format. This prevents the Docker warning `LegacyKeyValueFormat`. 

### Small request

If @carlosedp approves this pull request, would you mind updating the Docker image on the container registry (using the command outlined in the top of the `Dockerfile.golang`)? Thanks in advance!